### PR TITLE
feat(template): adds endpoint for generating from a template

### DIFF
--- a/src/document-service.ts
+++ b/src/document-service.ts
@@ -18,6 +18,14 @@ export class DocumentService {
         }
     }
 
+    setApiKey(apiKey: string) {
+        this.apiKey = apiKey;
+    }
+
+    setHost(host: string) {
+        this.host = host;
+    }
+
     /**
      * This method fetches the pre-signed data used to upload data to S3
      * @return {Promise<T>}
@@ -56,6 +64,18 @@ export class DocumentService {
 
         return this.request<DocumentServiceResponse.RegistrationResponse>({
             path: 'api/v1/content',
+            method: 'POST',
+            body: payload
+        });
+    }
+
+    generateMediaFromWordTemplate(payload: DocumentServiceOptions.WordTemplateRequestPayload) {
+        if (!payload || !payload.templateIdentity || !payload.payload) {
+            return new Error('Invalid template request');
+        }
+
+        return this.request<void>({
+            path: 'api/v1/word-template',
             method: 'POST',
             body: payload
         });

--- a/src/interfaces/document-service-options.interface.ts
+++ b/src/interfaces/document-service-options.interface.ts
@@ -47,7 +47,51 @@ export namespace DocumentServiceOptions {
         convertFormat?: string;
         // If a thumbnail should be generated
         shouldGenerateThumbnail?: boolean;
+        /**
+         * An open metadata field that will be returned on all callback
+         * requests.
+         */
+        metadata?: any;
     }
+
+    export interface WordTemplateRequestPayload {
+        /**
+         * Identity of the template for the request
+         */
+        templateIdentity: string;
+
+        /**
+         * The title of the output
+         */
+        title: string;
+
+        /**
+         * The payload to use for the template
+         */
+        payload: WordTemplatePayload;
+
+        /**
+         * Metadata used to identify the request upon callback
+         */
+        metadata: any;
+    }
+
+    export interface WordTemplatePayload {
+        replacements?: {
+            [key: string]: string;
+        };
+        images?: {
+            [key: string]: ImagePayload;
+        };
+    }
+
+    export interface ImagePayload {
+        url?: string;
+        svgString?: string;
+        height?: number;
+        width?: number;
+    }
+
 
     export interface ViewPayload {
         // The identity of the content


### PR DESCRIPTION
#### Short description of what this resolves:
- Adds call to generate content from a word template

### PR Checklist
- [ ] All `TODO`'s are done and removed
- [ ] `package.json` has correct information
- [ ] All dependencies are of correct type (regular vs peer vs dev)
- [ ] Documented any complicated or confusing code
- [ ] No linter errors
- [ ] Project packages successfully (`npm pack`)
- [ ] Installed local packed version in another project and tested
- [ ] Updated README


#### Changes proposed in this pull request:


**JIRA Task Link:**