### PR TITLE
feat: support word template returning dms content identity +resource url

### DIFF
--- a/src/document-service.ts
+++ b/src/document-service.ts
@@ -83,7 +83,7 @@ export class DocumentService {
             return new Error('Invalid template request');
         }
 
-        return this.request<void>({
+        return this.request<DocumentServiceResponse.WordTemplateRequestResponse>({
             path: 'api/v1/word-template',
             method: 'POST',
             body: payload,

--- a/src/interfaces/document-service-options.interface.ts
+++ b/src/interfaces/document-service-options.interface.ts
@@ -36,6 +36,8 @@ export namespace DocumentServiceOptions {
     }
 
     export interface RegistrationPayload {
+        // if provided, content will be created with this uuid as the identity
+        identity?: string;
         // The title of the content
         title: string;
         // The location of the content in S3

--- a/src/interfaces/document-service-response.interface.ts
+++ b/src/interfaces/document-service-response.interface.ts
@@ -34,6 +34,11 @@ export namespace DocumentServiceResponse {
         identity: string;
     }
 
+    export interface WordTemplateRequestResponse {
+        identity: string;
+        resourceUrl: string;
+    }
+
     export interface ViewResponse {
         // The status code
         statusCode: number;


### PR DESCRIPTION
#### Short description of what this resolves:
supports changes to dms that allow word template requests to return what the resource url and dms identity will be for the generated tempalte ahead of time so systems can register callbacks for that template

### PR Checklist
- [ ] All `TODO`'s are done and removed
- [ ] `package.json` has correct information
- [ ] All dependencies are of correct type (regular vs peer vs dev)
- [ ] Documented any complicated or confusing code
- [ ] No linter errors
- [ ] Project packages successfully (`npm pack`)
- [ ] Installed local packed version in another project and tested
- [ ] Updated README


#### Changes proposed in this pull request:


**JIRA Task Link:**